### PR TITLE
build: Fix Sonatype Central publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,21 +31,11 @@ jobs:
         os: [ubuntu-latest]
         scala: [2.12.20, 2.13.15]
         java: [temurin@8]
-        spark: [2.4.1, 2.4.7, 2.4.8, 3.0.1, 3.0.3, 3.1.1, 3.1.2, 3.1.3, 3.2.4, 3.3.4, 3.4.1, 3.4.4, 3.5.3]
+        spark: [2.4.8, 3.0.3, 3.1.3, 3.2.4, 3.3.4, 3.4.4, 3.5.3]
         exclude:
-          - spark: 2.4.1
-            scala: 2.13.15
-          - spark: 2.4.7
-            scala: 2.13.15
           - spark: 2.4.8
             scala: 2.13.15
-          - spark: 3.0.1
-            scala: 2.13.15
           - spark: 3.0.3
-            scala: 2.13.15
-          - spark: 3.1.1
-            scala: 2.13.15
-          - spark: 3.1.2
             scala: 2.13.15
           - spark: 3.1.3
             scala: 2.13.15
@@ -143,4 +133,4 @@ jobs:
           (echo "$PGP_PASSPHRASE"; echo; echo) | gpg --command-fd 0 --pinentry-mode loopback --change-passphrase $(gpg --list-secret-keys --with-colons 2> /dev/null | grep '^sec:' | cut --delimiter ':' --fields 5 | tail -n 1)
 
       - name: Publish
-        run: ./mill -i io.kipp.mill.ci.release.ReleaseModule/publishAll
+        run: ./mill -i mill.contrib.sonatypecentral.SonatypeCentralPublishModule/publishAll --publishArtifacts __.publishArtifacts --username $SONATYPE_USERNAME --password $SONATYPE_PASSWORD --gpgArgs "--passphrase=$PGP_PASSPHRASE,--no-tty,--pinentry-mode,loopback,--batch,--yes,-a,-b" --bundleName dev.mauch-spark-excel-$(date +%Y-%m-%d-%H-%M)

--- a/build.mill
+++ b/build.mill
@@ -1,10 +1,12 @@
-import $ivy.`io.chris-kipp::mill-ci-release::0.1.10`
-import io.kipp.mill.ci.release.CiReleaseModule
 import coursier.maven.MavenRepository
 import mill._, scalalib._, publish._
 import Assembly._
+import $ivy.`com.lihaoyi::mill-contrib-sonatypecentral:`
+import mill.contrib.sonatypecentral.SonatypeCentralPublishModule
+import $ivy.`de.tototec::de.tobiasroeser.mill.vcs.version::0.4.0`
+import de.tobiasroeser.mill.vcs.version.VcsVersion
 
-trait SparkModule extends Cross.Module2[String, String] with SbtModule with CiReleaseModule {
+trait SparkModule extends Cross.Module2[String, String] with SbtModule with SonatypeCentralPublishModule {
   outer =>
   override def scalaVersion = crossValue
   val sparkVersion = crossValue2
@@ -50,8 +52,10 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with CiRe
 
   override def artifactName = "spark-excel"
 
-  override def publishVersion = s"${sparkVersion}_${super.publishVersion()}"
-
+  override def publishVersion: T[String] = T {
+    val vcsVersion = VcsVersion.vcsState().format(untaggedSuffix = "-SNAPSHOT")
+    s"${sparkVersion}_${vcsVersion}"
+  }
   def pomSettings = PomSettings(
     description = "A Spark plugin for reading and writing Excel files",
     organization = "dev.mauch",
@@ -68,6 +72,16 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with CiRe
   )
 
   override def extraPublish = Seq(PublishInfo(assembly(), classifier = None, ivyConfig = "compile"))
+
+  def publishArtifacts: T[PublishModule.PublishData] = Task {
+    val publishData = super.publishArtifacts()
+    publishData.copy(
+      payload = publishData.payload.filterNot { case (ref, name) => ref.toString.contains("jar.dest") }
+    )
+  }
+
+  override def sonatypeCentralReadTimeout: T[Int] = 600000
+  override def sonatypeCentralAwaitTimeout: T[Int] = 1200 * 1000
 
   val sparkDeps = Agg(
     ivy"org.apache.spark::spark-core:$sparkVersion",
@@ -136,16 +150,17 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with CiRe
       ivy"org.scalamock::scalamock:5.2.0"
     )
   }
+
 }
 
 val scala213 = "2.13.15"
 val scala212 = "2.12.20"
-val spark24 = List("2.4.1", "2.4.7", "2.4.8")
-val spark30 = List("3.0.1", "3.0.3")
-val spark31 = List("3.1.1", "3.1.2", "3.1.3")
+val spark24 = List("2.4.8")
+val spark30 = List("3.0.3")
+val spark31 = List("3.1.3")
 val spark32 = List("3.2.4")
 val spark33 = List("3.3.4")
-val spark34 = List("3.4.1", "3.4.4")
+val spark34 = List("3.4.4")
 val spark35 = List("3.5.3")
 val sparkVersions = spark24 ++ spark30 ++ spark31 ++ spark32 ++ spark33 ++ spark34 ++ spark35
 val crossMatrix =


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Replaced the `CiReleaseModule` with `SonatypeCentralPublishModule` to align with Sonatype Central publishing requirements.
- Introduced new dependencies: `mill-contrib-sonatypecentral` and `mill.vcs.version` for enhanced versioning and publishing capabilities.
- Updated the `publishVersion` method to include VCS versioning with a `-SNAPSHOT` suffix for untagged versions.
- Added a `publishArtifacts` method to filter out unnecessary artifacts from the publishing payload.
- Configured extended read and await timeouts for Sonatype Central publishing.
- Streamlined Spark version lists by removing outdated versions.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.mill</strong><dd><code>Update build configuration for Sonatype Central publishing</code></dd></summary>
<hr>

build.mill

<li>Replaced <code>CiReleaseModule</code> with <code>SonatypeCentralPublishModule</code> for <br>publishing.<br> <li> Added dependencies for <code>mill-contrib-sonatypecentral</code> and <br><code>mill.vcs.version</code>.<br> <li> Updated <code>publishVersion</code> to use <code>VcsVersion</code> for versioning.<br> <li> Introduced <code>publishArtifacts</code> method to filter out specific artifacts.<br> <li> Adjusted Sonatype Central read and await timeout configurations.<br> <li> Simplified Spark version lists by removing older versions.<br>


</details>


  </td>
  <td><a href="https://github.com/nightscape/spark-excel/pull/905/files#diff-2b601da62851663bf0f9429195310d82df029448cc2f404c421798601585fb10">+24/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information