### PR TITLE
build: Read build matrix from Mill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,23 +16,28 @@ env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 jobs:
+  prepare:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Generate matrix
+        id: set-matrix
+        run: |
+          echo -n "matrix=" >> $GITHUB_OUTPUT
+          ./mill resolve "spark-excel[_,_]" | \
+          jq -Rsc 'split("\n") | map(capture("spark-excel\\[(?<scala>[^,]+),(?<spark>[^\\]]+)\\]") | select(.)) | {include: .}' >> $GITHUB_OUTPUT
+
   build:
+    needs: prepare
     name: Build and Test
     strategy:
       fail-fast: false
-      matrix:
-        os: [ubuntu-latest]
-        scala: [2.12.20, 2.13.15]
-        java: [temurin@11]
-        spark: [2.4.8, 3.0.3, 3.1.3, 3.2.4, 3.3.4, 3.4.4, 3.5.3]
-        exclude:
-          - spark: 2.4.8
-            scala: 2.13.15
-          - spark: 3.0.3
-            scala: 2.13.15
-          - spark: 3.1.3
-            scala: 2.13.15
-    runs-on: ${{ matrix.os }}
+      matrix: ${{ fromJson(needs.prepare.outputs.matrix) }}
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
@@ -41,14 +46,12 @@ jobs:
 
       - name: Download Java (temurin@11)
         id: download-java-temurin-11
-        if: matrix.java == 'temurin@11'
         uses: typelevel/download-java@v2
         with:
           distribution: temurin
           java-version: 11
 
       - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
         uses: actions/setup-java@v4
         with:
           distribution: jdkfile


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Introduced a new `prepare` job in the CI workflow to dynamically generate a build matrix using Mill and jq.
- Replaced the static build matrix in the `build` job with a dynamically generated matrix, improving maintainability and flexibility.
- Removed hardcoded matrix configurations and exclusions, simplifying the CI configuration.
- Updated the `build` job to depend on the `prepare` job, ensuring the dynamically generated matrix is used.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Dynamically generate build matrix using Mill in CI workflow</code></dd></summary>
<hr>

.github/workflows/ci.yml

<li>Added a new <code>prepare</code> job to generate a build matrix dynamically using <br>Mill and jq.<br> <li> Replaced the static build matrix in the <code>build</code> job with a dynamically <br>generated matrix from the <code>prepare</code> job.<br> <li> Removed hardcoded matrix configurations and exclusions, simplifying <br>the workflow.<br> <li> Updated the <code>build</code> job to depend on the <code>prepare</code> job for the matrix.


</details>


  </td>
  <td><a href="https://github.com/nightscape/spark-excel/pull/909/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+18/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information