### PR TITLE
use rowCacheSize to control max rows kept in memory

### DIFF
--- a/src/main/scala/dev/mauch/spark/excel/v2/ExcelHelper.scala
+++ b/src/main/scala/dev/mauch/spark/excel/v2/ExcelHelper.scala
@@ -107,7 +107,7 @@ class ExcelHelper private (options: ExcelOptions) {
     try {
       options.maxRowsInMemory match {
         case Some(maxRows) => {
-          val builder = StreamingReader.builder().bufferSize(maxRows)
+          val builder = StreamingReader.builder().rowCacheSize(maxRows)
           options.workbookPassword match {
             case Some(password) => builder.password(password)
             case _ =>


### PR DESCRIPTION
### **User description**
fixes #863

bufferSize is the number of bytes in the byte array when doing reads from InputStreams


___

### **PR Type**
- Bug fix



___

### **Description**
- Replace builder.bufferSize with builder.rowCacheSize.

- Correct API usage for maxRowsInMemory configuration.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ExcelHelper.scala</strong><dd><code>Replace bufferSize with rowCacheSize call.</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/main/scala/dev/mauch/spark/excel/v2/ExcelHelper.scala

<li>Changed builder.bufferSize(maxRows) to builder.rowCacheSize(maxRows).<br> <li> Aligns method call with intended functionality.


</details>


  </td>
  <td><a href="https://github.com/nightscape/spark-excel/pull/943/files#diff-5fff1207c0989daa5b187eec423641ab060dfdec0ae7924d512ab00230dd4c86">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>