### PR TITLE
Add `assembly` classifier to uber-jar, publish normal jar

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,7 +71,7 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with Sona
     Rule.Relocate("org.apache.commons.compress.**", "shadeio.commons.compress.@1")
   )
 
-  override def extraPublish = Seq(PublishInfo(assembly(), classifier = None, ivyConfig = "compile"))
+  override def extraPublish = Seq(PublishInfo(assembly(), classifier = Some("assembly"), ivyConfig = "compile"))
 
   def publishArtifacts: T[PublishModule.PublishData] = Task {
     val publishData = super.publishArtifacts()


### PR DESCRIPTION
With this change two dependency jars will be produced instead of the current one.

The current uber-jar will now have a `-assembly` suffix on the aretefact. In place of the un-classified jar will be a "thin" jar; one with just the `spark-excel` classes.

This change means end-users can avoid pulling in the uber-jar to environments where it may not be suitable, especially considering the uber-jar contains unshaded dependencies.

Resolves #852