### PR TITLE
Publish thin JAR alongside assembly JAR

### DIFF
--- a/build.mill
+++ b/build.mill
@@ -71,12 +71,10 @@ trait SparkModule extends Cross.Module2[String, String] with SbtModule with Sona
     Rule.Relocate("org.apache.commons.compress.**", "shadeio.commons.compress.@1")
   )
 
-  override def extraPublish = Seq(PublishInfo(assembly(), classifier = None, ivyConfig = "compile"))
-
-  def publishArtifacts: T[PublishModule.PublishData] = Task {
-    val publishData = super.publishArtifacts()
-    publishData.copy(payload = publishData.payload.filterNot { case (ref, name) => ref.toString.contains("jar.dest") })
-  }
+  override def extraPublish = Seq(
+    PublishInfo(assembly(), classifier = None, ivyConfig = "compile"),
+    PublishInfo(jar(), classifier = Some("thin"), ivyConfig = "compile")
+  )
 
   override def sonatypeCentralReadTimeout: T[Int] = 600000
   override def sonatypeCentralAwaitTimeout: T[Int] = 1200 * 1000


### PR DESCRIPTION
### **User description**
This PR has been implemented by Jules.


___

### **PR Type**
Enhancement


___

### **Description**
Add thin JAR publication with 'thin' classifier
Preserve existing assembly JAR without classifier
Remove filter preventing default JAR publishing


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>build.mill</strong><dd><code>Include thin JAR in publication artifacts</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

build.mill

<li>Added PublishInfo for thin JAR with classifier<br> <li> Kept assembly JAR PublishInfo unchanged<br> <li> Removed payload filter in publishArtifacts


</details>


  </td>
  <td><a href="https://github.com/nightscape/spark-excel/pull/964/files#diff-2b601da62851663bf0f9429195310d82df029448cc2f404c421798601585fb10">+6/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about PR-Agent usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>